### PR TITLE
Feature: Add reverse in player movement

### DIFF
--- a/server/public/js/domain/player.js
+++ b/server/public/js/domain/player.js
@@ -120,7 +120,9 @@ window.Player = class Player extends GenericPlayer {
 
         if (cursors.up.isDown) {
             physics.velocityFromRotation(this.ship.rotation + 1.5, 500, this.ship.body.acceleration);
-        } else {
+        } else if (cursors.down.isDown) {
+            physics.velocityFromRotation(this.ship.rotation + 1.5, -500, this.ship.body.acceleration);
+        }else{
             this.ship.setAcceleration(0);
         }
 


### PR DESCRIPTION
![Alt Text](https://i.imgur.com/ZFtuzqi.gif)
When you reverse and turn, the ship turns towards the side you are pressing, the other way around than in a car. Which to me feels more natural to aim.

The speed is the same that when you go forward, but it can be changed.